### PR TITLE
Better configuration for the Metrics endpoint

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,6 +38,8 @@ jobs:
       - uses: nicknovitski/nix-develop@v1
       - run: |
           echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "$DOCKERHUB_USER" --password-stdin
+          echo "username = \"${{ secrets.METRICS_USERNAME }}\"" >> docker-digitalocean/config.toml
+          echo "password = \"${{ secrets.METRICS_PASSWORD }}\"" >> docker-digitalocean/config.toml
           make dockerdo DOCKER_PLATFORM=linux/amd64
           docker push --all-tags "$DOCKERHUB_USER/$DOCKERHUB_REPOSITORY"
     needs: docker-build-multiplatform

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Gleeter is known to work well with the following terminals:
 *   [Ghostty](https://ghostty.dev/)
 *   [Kitty](https://sw.kovidgoyal.net/kitty/)
 *   [Wezterm](https://wezfurlong.org/wezterm/)
-*   [iTerm2](https://iterm2.com/)
 *   ... and probably more
 
 ## Test it out now

--- a/README.md
+++ b/README.md
@@ -87,19 +87,27 @@ type = "random"
 [[alias]]
 name = "l"
 type = "latest"
+
+[metrics]
+ignore_base_path = true
+username = "your_username"
+password = "your_password"
 ```
 
 ### Structure and Usage
 
 The configuration file is loaded when Gleeter starts. Gleeter looks for the configuration file in `$XDG_CONFIG_HOME/gleeter/config.toml` or `$HOME/.config/gleeter/config.toml`. If neither of these is found, it uses `./config.toml`.  The settings defined in the file are used to initialize the application and control its behavior.
 
-*   **`random_start`**: Specifies the starting comic number for the random comic selection. If not specified, a default value is used.
+*   `random_start`: Specifies the starting comic number for the random comic selection. If not specified, a default value is used.
 
-*   **`[screen]`**: This section configures the screen dimensions for displaying comics.
+*   `[screen]`: This section configures the screen dimensions for displaying comics.
     *   `max_cols`: Specifies the maximum number of columns to use for displaying the comic.
     *   `max_lines`: Specifies the maximum number of lines to use for displaying the comic.
-
-*   `[[alias]]`**: This section defines aliases for accessing comics. You can define multiple aliases.
+*   `[metrics]`: This section configures the metrics endpoint.
+    *   `ignore_base_path`: If set to `true`, the `/metrics` endpoint will be accessible even when a base path is used. This allows accessing metrics at `/metrics` regardless of the configured base path.
+    *   `username`: An optional username for basic authentication on the `/metrics` endpoint. If provided, a password must also be specified.
+    *   `password`: An optional password for basic authentication on the `/metrics` endpoint. If provided, a username must also be specified.
+*   `[[alias]]`: This section defines aliases for accessing comics. You can define multiple aliases.
     *   `name`: The name of the alias. Alias names **must not** be empty and **must not** contain any of the following characters: `!`, `;`, `$`, `:`, `\`, `"`, `'`, `(`, `)`, space, tab, newline, or carriage return. Leading and trailing whitespaces will be automatically removed.
     *   `type`: The type of alias. Valid values are `"id"`, `"random"`, and `"latest"`.
     *   `id`: (Only required for `"id"` aliases) The comic ID to associate with the alias.
@@ -183,7 +191,9 @@ This endpoint can be useful for monitoring the health and performance of the ser
 
 #### Prometheus Metrics
 
-Gleeter exposes Prometheus metrics that can be used to monitor the server's performance and health. These metrics are available at the `/<base_path>/metrics` endpoint in the Prometheus format.
+Gleeter exposes Prometheus metrics that can be used to monitor the server's performance and health. These metrics are available at the `/<base_path>/metrics` and **optionally** also at the `/metrics` path (the behavior is configurable via the configuration file).
+
+It is also possible to protect the endpoint with basic authentication by setting a username and password in the configuration file. If authentication is enabled, you will need to provide the correct credentials to access the metrics endpoint. Only [Basic authorization](https://en.wikipedia.org/wiki/Basic_access_authentication) is supported right now.
 
 The following metrics are exposed:
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The configuration file is loaded when Gleeter starts. Gleeter looks for the conf
 *   `[screen]`: This section configures the screen dimensions for displaying comics.
     *   `max_cols`: Specifies the maximum number of columns to use for displaying the comic.
     *   `max_lines`: Specifies the maximum number of lines to use for displaying the comic.
-*   `[metrics]`: This section configures the metrics endpoint.
+*   `[metrics]`: This section configures the [metrics](#prometheus-metrics) endpoint and it is meaningful only for the `serve` mode.
     *   `ignore_base_path`: If set to `true`, the `/metrics` endpoint will be accessible even when a base path is used. This allows accessing metrics at `/metrics` regardless of the configured base path.
     *   `username`: An optional username for basic authentication on the `/metrics` endpoint. If provided, a password must also be specified.
     *   `password`: An optional password for basic authentication on the `/metrics` endpoint. If provided, a username must also be specified.
@@ -121,6 +121,7 @@ To modify Gleeter's behavior, simply edit the configuration file and restart the
 When Gleeter is run in `serve` mode, it starts an HTTP server that exposes the following endpoints:
 
 *   `/`: Serves the latest comic.
+*   `/metrics/`: Serves the [Prometheus metrics](#prometheus-metrics) endpoint.
 *   `/latest`: Serves the latest comic (same as `/`).
 *   `/random`: Serves a random comic.
 *   `/id/<number>`: Serves the comic with the specified ID. Replace `<number>` with the desired comic ID.
@@ -128,6 +129,7 @@ When Gleeter is run in `serve` mode, it starts an HTTP server that exposes the f
 You can customize the base path for these endpoints by using the `<base_path>` argument. For example, if you start the server with `gleeter serve 8080 /comics`, the endpoints will be:
 
 *   `/comics/`
+*   `/comics/metrics`
 *   `/comics/latest`
 *   `/comics/random`
 *   `/comics/id/<number>`

--- a/docker-digitalocean/config.toml
+++ b/docker-digitalocean/config.toml
@@ -46,3 +46,6 @@ id = 552
 [[alias]]
 name = "r"
 type = "random"
+
+[metrics]
+ignore_base_path = true

--- a/src/gleeter/config.gleam
+++ b/src/gleeter/config.gleam
@@ -12,7 +12,15 @@ pub type Configuration {
     random_start: option.Option(Int),
     max_cols: option.Option(Int),
     max_lines: option.Option(Int),
+    metrics_configuration: option.Option(MetricsConfiguration),
     aliases: List(Alias),
+  )
+}
+
+pub type MetricsConfiguration {
+  MetricsConfiguration(
+    ignore_base_path: Bool,
+    auth_credentials: option.Option(#(String, String)),
   )
 }
 
@@ -30,6 +38,7 @@ fn default() -> Configuration {
     random_start: option.None,
     max_cols: option.None,
     max_lines: option.None,
+    metrics_configuration: option.None,
     aliases: [],
   )
 }
@@ -105,6 +114,26 @@ fn validate_name(in: Result(String, a)) -> NameString {
   }
 }
 
+fn parse_metrics_configuration(
+  in: Result(dict.Dict(String, tom.Toml), b),
+) -> option.Option(MetricsConfiguration) {
+  case in {
+    Error(_) -> option.None
+    Ok(parsed) -> {
+      let ignore_base_path = tom.get_bool(parsed, ["ignore_base_path"])
+      let username = tom.get_string(parsed, ["username"])
+      let password = tom.get_string(parsed, ["password"])
+
+      case ignore_base_path, username, password {
+        Ok(ib), Ok(u), Ok(p) ->
+          option.Some(MetricsConfiguration(ib, option.Some(#(u, p))))
+        Ok(ib), _, _ -> option.Some(MetricsConfiguration(ib, option.None))
+        _, _, _ -> option.None
+      }
+    }
+  }
+}
+
 fn parse_alias(in: dict.Dict(String, tom.Toml)) -> option.Option(Alias) {
   let name = tom.get_string(in, ["name"]) |> validate_name
   let alias_type = tom.get_string(in, ["type"]) |> option.from_result
@@ -156,5 +185,14 @@ pub fn parse(in: ConfigFile) -> Configuration {
       alias
     })
 
-  Configuration(random_start, max_cols, max_lines, aliases)
+  let metrics_configuration =
+    parse_metrics_configuration(tom.get_table(parsed, ["metrics"]))
+
+  Configuration(
+    random_start,
+    max_cols,
+    max_lines,
+    metrics_configuration,
+    aliases,
+  )
 }

--- a/src/gleeter/serve.gleam
+++ b/src/gleeter/serve.gleam
@@ -243,13 +243,22 @@ fn to_printable(
 }
 
 /// Given a base path and a path, strip the base path from the path
-fn strip_base_path(
+pub fn strip_base_path(
   base_path: List(String),
   received_path: List(String),
+  configuration: config.Configuration,
 ) -> Result(List(String), Nil) {
+  let metrics_ignore_base_path = {
+    case configuration.metrics_configuration {
+      option.None -> False
+      option.Some(mc) -> mc.ignore_base_path
+    }
+  }
+
   case base_path, received_path {
+    _, ["metrics"] if metrics_ignore_base_path -> Ok(["metrics"])
     [], rest -> Ok(rest)
-    [x, ..xs], [y, ..ys] if x == y -> strip_base_path(xs, ys)
+    [x, ..xs], [y, ..ys] if x == y -> strip_base_path(xs, ys, configuration)
     [_, ..], [_, ..] -> Error(Nil)
     _, [] -> Error(Nil)
   }
@@ -269,7 +278,7 @@ fn handler(base_path: String) -> fn(StatefulRequest) -> rr.MResponse {
     let ApplicationContext(cache, config, actor) as context = rr.state(s)
     let path_segments =
       base_path
-      |> strip_base_path(handle.path_segments(s))
+      |> strip_base_path(handle.path_segments(s), config)
 
     use terminal_columns <- handle.require_valid_optional_header(
       s,

--- a/src/gleeter/serve.gleam
+++ b/src/gleeter/serve.gleam
@@ -1,12 +1,13 @@
 import birl
 import birl/duration
+import gleam/bit_array
 import gleam/bytes_tree
 import gleam/erlang/process
 import gleam/int
 import gleam/io
 import gleam/json
 import gleam/list
-import gleam/option
+import gleam/option.{type Option, None, Some}
 import gleam/otp/actor
 import gleam/result
 import gleam/string_tree
@@ -134,11 +135,11 @@ fn handle_random(cache: cache.Cache) -> Result(cache.ComicWithData, Nil) {
   let random = int.random(number + 1)
 
   let result = case cache.get_comic(cache, random) {
-    option.Some(cwd) -> {
+    Some(cwd) -> {
       metrics.increment_cache_hits("random")
       Ok(cwd)
     }
-    option.None -> {
+    None -> {
       metrics.increment_cache_miss("random")
       debug_print("Not found in cache: " <> int.to_string(random))
       use xkcd <- result.try(xkcd.get_comic |> wrap_nil1(random))
@@ -184,11 +185,11 @@ fn handle_id(cache: cache.Cache, id: Int) -> Result(cache.ComicWithData, Nil) {
   debug_print("Handling id: " <> int.to_string(id))
   let start = birl.now()
   let result = case cache.get_comic(cache, id) {
-    option.Some(cwd) -> {
+    Some(cwd) -> {
       metrics.increment_cache_hits("id")
       Ok(cwd)
     }
-    option.None -> {
+    None -> {
       metrics.increment_cache_miss("id")
       debug_print("Not found in cache: " <> int.to_string(id))
       use xkcd <- result.try(xkcd.get_comic |> wrap_nil1(id))
@@ -216,10 +217,10 @@ fn handle_id(cache: cache.Cache, id: Int) -> Result(cache.ComicWithData, Nil) {
 
 fn to_printable(
   in: cache.ComicWithData,
-  terminal_size: option.Option(graphics.TerminalSize),
+  terminal_size: Option(graphics.TerminalSize),
 ) -> bytes_tree.BytesTree {
   let data = case terminal_size, png.get_image_size(in.raw_data) {
-    option.Some(ts), Ok(is) -> {
+    Some(ts), Ok(is) -> {
       graphics.resize_image(in.data, is, ts)
     }
     _, _ -> in.data
@@ -250,8 +251,8 @@ pub fn strip_base_path(
 ) -> Result(List(String), Nil) {
   let metrics_ignore_base_path = {
     case configuration.metrics_configuration {
-      option.None -> False
-      option.Some(mc) -> mc.ignore_base_path
+      None -> False
+      Some(mc) -> mc.ignore_base_path
     }
   }
 
@@ -268,6 +269,59 @@ type PathResult {
   Json(json.Json, Int)
   Comic(cache.ComicWithData)
   Prometheus(String)
+}
+
+/// This will first check if an authentication is needed
+fn handle_metrics(
+  config: config.Configuration,
+  s: StatefulRequest,
+) -> PathResult {
+  // First, build the expected base64 encoded stuff, if needed
+  let base64_creds = {
+    use creds <- option.then(config.metrics_configuration)
+    use #(username, password) <- option.then(creds.auth_credentials)
+
+    bytes_tree.new()
+    |> bytes_tree.append_string(username)
+    |> bytes_tree.append_string(":")
+    |> bytes_tree.append_string(password)
+    |> bytes_tree.to_bit_array()
+    |> bit_array.base64_encode(True)
+    |> Some
+  }
+
+  // Then, retrieve the header and strip away the unneeded part
+  let authorization_header = {
+    use header <- option.then(handle.get_header(s, "Authorization"))
+    case header {
+      "Basic " <> base64_received_creds -> Some(base64_received_creds)
+      _ -> None
+    }
+  }
+
+  // Lazily calculate the result
+  let ok_path = fn() {
+    metrics.update_memory()
+    case themis.print() {
+      Ok(p) -> Prometheus(p)
+      Error(_) -> Prometheus("")
+    }
+  }
+
+  case base64_creds, authorization_header {
+    // No authentication needed, we do not care about the header stuff
+    None, _ -> ok_path()
+
+    // Authentication needed, we have the header and the two encoded strings match
+    Some(creds), Some(received_creds) if creds == received_creds -> ok_path()
+
+    // If we are here, the authentication is needed but the header is either missing or invalid
+    _, _ -> {
+      ApiError("Unauthorized")
+      |> encode_api_error()
+      |> Json(401)
+    }
+  }
 }
 
 fn handler(base_path: String) -> fn(StatefulRequest) -> rr.MResponse {
@@ -293,9 +347,8 @@ fn handler(base_path: String) -> fn(StatefulRequest) -> rr.MResponse {
     )
 
     let terminal_size = case terminal_columns, terminal_rows {
-      option.Some(columns), option.Some(rows) ->
-        option.Some(graphics.TerminalSize(rows, columns))
-      _, _ -> option.None
+      Some(columns), Some(rows) -> Some(graphics.TerminalSize(rows, columns))
+      _, _ -> None
     }
 
     let comic_or_error = fn(
@@ -314,13 +367,7 @@ fn handler(base_path: String) -> fn(StatefulRequest) -> rr.MResponse {
             |> encode_health_check
             |> Json(200)
           }
-          ["metrics"] -> {
-            metrics.update_memory()
-            case themis.print() {
-              Ok(s) -> Prometheus(s)
-              Error(_) -> Prometheus("")
-            }
-          }
+          ["metrics"] -> handle_metrics(config, s)
           ["random"] -> {
             handle_random(cache)
             |> comic_or_error("Failed to load random comic")

--- a/test/gleeter/config_test.gleam
+++ b/test/gleeter/config_test.gleam
@@ -1,8 +1,8 @@
 import envoy
 import gleam/option.{None, Some}
 import gleeter/config.{
-  Configuration, IdAlias, LatestAlias, RandomAlias, get_configuration_file,
-  parse,
+  Configuration, IdAlias, LatestAlias, MetricsConfiguration, RandomAlias,
+  get_configuration_file, parse,
 }
 import startest.{describe, it}
 import startest/expect
@@ -27,7 +27,7 @@ pub fn config_tests() -> test_tree.TestTree {
     it("parses configuration", fn() {
       parse("test_data/config.toml")
       |> expect.to_equal(
-        Configuration(Some(38), Some(80), Some(23), [
+        Configuration(Some(38), Some(80), Some(23), None, [
           IdAlias("bobbytables", 987),
           IdAlias("trimmed_alias", 987),
           RandomAlias("rnd"),
@@ -38,12 +38,38 @@ pub fn config_tests() -> test_tree.TestTree {
     it("ignores invalid stuff", fn() {
       parse("test_data/config_invalid.toml")
       |> expect.to_equal(
-        Configuration(None, Some(31), None, [IdAlias("valid", 123)]),
+        Configuration(None, Some(31), None, None, [IdAlias("valid", 123)]),
       )
     }),
     it("returns empty configuration if file is missing", fn() {
       parse("test_data/nonexistant.toml")
-      |> expect.to_equal(Configuration(None, None, None, []))
+      |> expect.to_equal(Configuration(None, None, None, None, []))
     }),
+    describe("metrics", [
+      it("parses all values if they are present", fn() {
+        parse("test_data/config_metrics.toml")
+        |> expect.to_equal(
+          Configuration(
+            None,
+            None,
+            None,
+            Some(MetricsConfiguration(True, Some(#("username", "password")))),
+            [],
+          ),
+        )
+      }),
+      it("skips username or password if one is missing", fn() {
+        parse("test_data/config_metrics_missing.toml")
+        |> expect.to_equal(
+          Configuration(
+            None,
+            None,
+            None,
+            Some(MetricsConfiguration(False, None)),
+            [],
+          ),
+        )
+      }),
+    ]),
   ])
 }

--- a/test/gleeter/serve_test.gleam
+++ b/test/gleeter/serve_test.gleam
@@ -1,0 +1,30 @@
+import gleam/option.{None, Some}
+import gleeter/config
+import gleeter/serve
+import startest.{describe, it}
+import startest/expect
+import startest/test_tree.{type TestTree}
+
+pub fn serve_tests() -> TestTree {
+  let default_empty_config = config.Configuration(None, None, None, None, [])
+
+  let metrics_config = config.MetricsConfiguration(True, None)
+  let config_with_ignore =
+    config.Configuration(None, None, None, Some(metrics_config), [])
+  describe("gleeter/serve", [
+    it("strips base path", fn() {
+      serve.strip_base_path(["a", "b"], ["a", "b", "c"], default_empty_config)
+      |> expect.to_be_ok()
+      |> expect.to_equal(["c"])
+    }),
+    it("errors if request does not match", fn() {
+      serve.strip_base_path(["a", "b"], ["metrics"], default_empty_config)
+      |> expect.to_be_error()
+    }),
+    it("ignores base path for /metrics if specified", fn() {
+      serve.strip_base_path(["a", "b"], ["metrics"], config_with_ignore)
+      |> expect.to_be_ok()
+      |> expect.to_equal(["metrics"])
+    }),
+  ])
+}

--- a/test_data/config_metrics.toml
+++ b/test_data/config_metrics.toml
@@ -1,0 +1,4 @@
+[metrics]
+ignore_base_path = true
+username = "username"
+password = "password"

--- a/test_data/config_metrics_missing.toml
+++ b/test_data/config_metrics_missing.toml
@@ -1,0 +1,4 @@
+[metrics]
+ignore_base_path = false
+username = "something"
+# Missing password, so this is invalid


### PR DESCRIPTION
Things done:
- add new metrics section in the configuration
- make it possible for /metrics to ignore the base path
- protect the metrics endpoint with Basic Auth
