### PR TITLE
Allow to load the configuration file from a different location

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,47 @@ For example, to fetch a random comic using the latest version of Gleeter, you wo
 docker run --rm massix86/gleeter:latest -- random
 ```
 
+To use a configuration file with the Docker image, follow these steps:
+
+1.  Create a `config.toml` file with your desired configuration settings. For example:
+
+    ```toml
+    random_start = 100
+
+    [screen]
+    max_cols = 100
+    max_lines = 30
+
+    [[alias]]
+    name = "bobbytables"
+    type = "id"
+    id = 987
+
+    [[alias]]
+    name = "rnd"
+    type = "random"
+
+    [[alias]]
+    name = "l"
+    type = "latest"
+    ```
+
+2.  Run the Docker image with a bind mount to map the `config.toml` file from your host machine into the container, and set the `GLEETER_CONFIG_FILE` environment variable to point to the mounted file:
+
+    ```bash
+    docker run --rm -v $(pwd)/config.toml:/app/config.toml -e GLEETER_CONFIG_FILE=/app/config.toml massix86/gleeter:latest -- bobbytables
+    ```
+
+    This command does the following:
+
+    *   `--rm`: Automatically removes the container when it exits.
+    *   `-v $(pwd)/config.toml:/app/config.toml`: Creates a bind mount, mapping the `config.toml` file in the current directory (`$(pwd)`) on your host machine to the `/app/config.toml` path inside the container.
+    *   `-e GLEETER_CONFIG_FILE=/app/config.toml`: Sets the `GLEETER_CONFIG_FILE` environment variable inside the container to `/app/config.toml`. This tells Gleeter where to find the configuration file.
+    *   `massix86/gleeter:latest`: Specifies the Docker image to use.
+    *   `-- bobbytables`: Tells Gleeter to fetch the comic pointed by the bobbytables alias.
+
+Make sure that the `config.toml` file exists in the current directory when you run the Docker command.
+
 ### Other systems
 
 To install on other systems, ensure you have Gleam and Erlang installed. Then, you can build and run the project using Gleam's build tools. Refer to the Gleam documentation for specific instructions.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,14 @@ password = "your_password"
 
 ### Structure and Usage
 
-The configuration file is loaded when Gleeter starts. Gleeter looks for the configuration file in `$XDG_CONFIG_HOME/gleeter/config.toml` or `$HOME/.config/gleeter/config.toml`. If neither of these is found, it uses `./config.toml`.  The settings defined in the file are used to initialize the application and control its behavior.
+The configuration file is loaded when Gleeter starts. Gleeter checks for the configuration file in the following order:
+
+1.  `$GLEETER_CONFIG_FILE`: If this environment variable is set, Gleeter will attempt to load the configuration file from the path specified. This variable *must* point to a valid TOML file.
+2.  `$XDG_CONFIG_HOME/gleeter/config.toml`: If `$GLEETER_CONFIG_FILE` is not set, Gleeter will check for a configuration file in the `$XDG_CONFIG_HOME` directory, appending `/gleeter/config.toml` to the value of the variable.
+3.  `$HOME/.config/gleeter/config.toml`: If `$XDG_CONFIG_HOME` is not set, Gleeter will check for a configuration file in the `$HOME` directory, appending `/.config/gleeter/config.toml` to the value of the variable.
+4.  `./gleeter/config.toml`: If none of the above environment variables are set, Gleeter will attempt to load the configuration file from the `./gleeter/config.toml` path.
+
+The settings defined in the file are used to initialize the application and control its behavior.
 
 *   `random_start`: Specifies the starting comic number for the random comic selection. If not specified, a default value is used.
 

--- a/src/gleeter/config.gleam
+++ b/src/gleeter/config.gleam
@@ -155,11 +155,18 @@ fn parse_alias(in: dict.Dict(String, tom.Toml)) -> option.Option(Alias) {
 
 pub fn get_configuration_file() -> ConfigFile {
   let assert Ok(path) =
-    envoy.get("XDG_CONFIG_HOME")
-    |> result.or(envoy.get("HOME") |> result.map(fn(s) { s <> "/.config" }))
-    |> result.or(Ok("."))
+    envoy.get("GLEETER_CONFIG_FILE")
+    |> result.or(
+      envoy.get("XDG_CONFIG_HOME")
+      |> result.map(fn(s) { s <> "/gleeter/config.toml" }),
+    )
+    |> result.or(
+      envoy.get("HOME")
+      |> result.map(fn(s) { s <> "/.config/gleeter/config.toml" }),
+    )
+    |> result.or(Ok("./gleeter/config.toml"))
 
-  path <> "/gleeter/config.toml"
+  path
 }
 
 pub fn parse(in: ConfigFile) -> Configuration {

--- a/test/gleeter/config_test.gleam
+++ b/test/gleeter/config_test.gleam
@@ -11,8 +11,15 @@ import startest/test_tree
 pub fn config_tests() -> test_tree.TestTree {
   describe("gleeter/config", [
     it("returns the path for the configuration file", fn() {
+      // Here we are also testing the different priority levels.
+      envoy.set("GLEETER_CONFIG_FILE", "/tmp/config.toml")
       envoy.set("HOME", "/home/user")
       envoy.set("XDG_CONFIG_HOME", "/home/user/.config")
+
+      get_configuration_file()
+      |> expect.to_equal("/tmp/config.toml")
+
+      envoy.unset("GLEETER_CONFIG_FILE")
       get_configuration_file()
       |> expect.to_equal("/home/user/.config/gleeter/config.toml")
 


### PR DESCRIPTION
# Description
It is now possible to create a `GLEETER_CONFIG_FILE` location, which will be tested first when loading the config file.
